### PR TITLE
Add scanHandler to tribrid/examples code

### DIFF
--- a/examples/tribrid/scan-handler/InstrumentHandler.cs
+++ b/examples/tribrid/scan-handler/InstrumentHandler.cs
@@ -1,0 +1,298 @@
+﻿/*
+ * 
+ * ScanHandler C# Implementation
+ * Author: Devin K Schweppe
+ * Copyright: 2022-2023 Schweppe Lab, University of Washington
+ * 
+ * Instrument Handler classes for Thermo Instruments
+ * 
+ */
+using ScanHandler.lib;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Thermo.Interfaces.FusionAccess_V1;
+using Thermo.Interfaces.FusionAccess_V1.Control;
+using Thermo.Interfaces.FusionAccess_V1.MsScanContainer;
+// Thermo Libraries
+using Thermo.Interfaces.InstrumentAccess_V1.Control.Acquisition;
+using Thermo.Interfaces.InstrumentAccess_V1.Control.InstrumentValues;
+using Thermo.Interfaces.InstrumentAccess_V1.Control.Scans;
+using Thermo.Interfaces.InstrumentAccess_V1.MsScanContainer;
+using Thermo.TNG.Factory;
+using Thermo.Interfaces.InstrumentAccess_V1;
+
+namespace ScanHandler
+{
+    /// <summary>
+    /// Class to handle all instrument interactions.
+    /// </summary>
+    public partial class InstrumentHandler
+    {
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        /// <summary>
+        /// Global objects for scan processing.
+        /// </summary>
+        //Instrument Control
+        IFusionInstrumentAccessContainer _instAccessContainer;
+        IFusionInstrumentAccess _instAccess;
+        IFusionMsScanContainer _instMSScanContainer;
+        IAcquisition _instAcq;
+        IFusionControl _instControl;
+        IInstrumentValues _instValues;
+        IScans _scans;
+
+        /// <summary>
+        /// The current scan being processed
+        /// </summary>
+        public Scan CurrentScan { get; set; }
+
+        /// <summary>
+        /// The scan processor for processing converted raw data.
+        /// </summary>
+        public static ScanProcessor scanProcessor { get; set; }
+
+        /// <summary>
+        /// Allow delayed access point for instrument
+        /// </summary>
+        EventWaitHandle accessWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset);
+
+        /// <summary>
+        /// Check for whether the api is present and engaged
+        /// </summary>
+        public bool Instrument_engaged { get; set; } = false;
+
+        /// <summary>
+        /// Check for whether report lisetener is on.
+        /// </summary>
+        public bool Listening_For_Report { get; set; } = false;
+
+        /// <summary>
+        /// Bool to allow immediate scan handling when instrument is not in the `Running` state.
+        /// </summary>
+        public static bool Immediate_Start { get; set; } = false;
+
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        /// <summary>
+        /// Start instrument access, initiate access, and bind a new listener to scan arrival using the user's method
+        /// </summary>
+        public void Run(Func<Scan, Dictionary<string, string>> user_scan_Method, Action<object, ScanReportArgs> user_report_Method)
+        {
+            if (CreateAccessContainer())
+            {
+                Console.WriteLine("Access container created in UI.");
+            }
+            else
+            {
+                Console.WriteLine("Unable to establish instrument access.");
+            }
+
+            if (!InitiateInstrumentAccess(user_scan_Method))
+            {
+                Console.WriteLine("Unable to initiate instrument access.");
+            }
+
+            // Add filters for when and how to bind events
+            BindScanListenerToScanArrival(true);
+
+            //Bind report listener for data outputs
+            BindReportMethod(user_report_Method, true);
+
+        }
+
+        /// <summary>
+        /// Stop the listener for scan arrival and clear custom scans.
+        /// </summary>
+        public void Stop()
+        {
+            try
+            {
+                //stop extra custom scans after stop button
+                if (_scans != null)
+                {
+                    _scans.CancelCustomScan();
+                }
+
+                //
+                // Add filters for when and how to bind events
+                //
+                BindScanListenerToScanArrival(false);
+
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+
+        /// <summary>
+        /// Create container for instrument access
+        /// </summary>
+        /// <returns></returns>
+        public bool CreateAccessContainer()
+        {
+            try
+            {
+                _instAccessContainer = Factory<IFusionInstrumentAccessContainer>.Create();
+
+                _instAccessContainer.ServiceConnectionChanged += _instAccessContainer_ServiceConnectionChanged;
+
+                Instrument_engaged = true;
+
+                return Instrument_engaged;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                Instrument_engaged = false;
+
+                return Instrument_engaged;
+            }
+        }
+
+        /// <summary>
+        /// Set wait handle when access has changed.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        void _instAccessContainer_ServiceConnectionChanged(object sender, EventArgs e)
+        {
+            accessWaitHandle.Set();
+            Console.WriteLine("Service connection Changed.");
+        }
+        private void _instAcq_StateChanged(object sender, StateChangedEventArgs e)
+        {
+            //UpdateInstrumentState(e.State);
+        }
+        public string GetInstrumentAcqState()
+        {
+            return _instAcq.State.SystemState.ToString();
+        }
+        /// <summary>
+        /// Scan listener to catch new scans arriving.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void _instMSScanContainer_MsScanArrived(object sender, MsScanEventArgs e)
+        {
+            try
+            {
+                //if instrument state not running (e.g. between runs) and not set to immediate start then unbind scan listener
+                if (_instAcq.State.SystemState != InstrumentState.Running & !Immediate_Start)
+                {
+                    Console.WriteLine("Instrument not current running, unbinding scan listener.");
+                    BindScanListenerToScanArrival(false);
+                    return;
+                }
+
+                // Pull new scan from MsScanEventArgs
+                IMsScan iMsScan = e.GetScan();
+
+                // Load new scan and push into Scan class.
+                string sTemp = (iMsScan.Trailer.TryGetValue("Scan Description", out sTemp)) ? sTemp : "";
+                string sScannumber = "";
+                string mso = "";
+                if (!iMsScan.Header.TryGetValue("Scan", out sScannumber))
+                {
+                    iMsScan.Header.TryGetValue("ScanNumber", out sScannumber);
+                }
+                int scannum = int.Parse(sScannumber);
+
+                int iMsorder = 1;
+                if (iMsScan.Header.TryGetValue("MSOrder", out mso) && !int.TryParse(mso, out iMsorder))
+                {
+                    Enum.TryParse(mso, out MSOrderType mSOrderType);
+                    iMsorder = (int)mSOrderType;
+                }
+                else if (iMsScan.Header.TryGetValue("MSOrder", out mso))
+                {
+                    iMsorder = int.Parse(mso);
+                }
+                iMsScan.Trailer.TryGetValue("FAIMS Voltage On", out string FAIMSState);
+                if (FAIMSState == "True")
+                {
+                    FAIMSState = "On";
+                }
+                else if (FAIMSState == "False")
+                {
+                    FAIMSState = "Off";
+                }
+                iMsScan.Trailer.TryGetValue("FAIMS CV", out string FAIMSCV);
+
+                //will likely want to also pass the centroids and other scan data from here
+                CurrentScan = new Scan
+                {
+                    ScanNumber = scannum,
+                    MsOrder = iMsorder,
+                    ScanDescription = sTemp,
+                    FAIMS_Voltages = FAIMSState,
+                    FAIMS_CV = FAIMSCV,
+                };
+
+                CurrentScan.ConvertIMsScan(iMsScan.Centroids);
+
+                //clear the IMsScan information before processing begins to save memory and stop latency issues
+                iMsScan = null;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                return;
+            }
+
+            ///
+            /// Now that scans have been converted to ScanHandler format, process them as needed!
+            ///
+            try
+            {
+                scanProcessor.ProcessNewScan(CurrentScan);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        } //scan listener
+
+        /// <summary>
+        /// Initiate steps to allow instrument access from ScanHandler
+        /// </summary>
+        public bool InitiateInstrumentAccess(Func<Scan, Dictionary<string, string>> scan_processing_Method,
+            Func<Scan, Dictionary<string, string>> scan_reporting_Method = null)
+        {
+            if (_instAccessContainer == null)
+            {
+                throw new Exception("No instrument access container.");
+            }
+
+            try
+            {
+                _instAccessContainer.StartOnlineAccess();
+
+                accessWaitHandle.WaitOne();
+
+                _instAccess = _instAccessContainer.Get(1);
+
+                _instControl = _instAccess.Control;
+
+                _instAcq = _instControl.Acquisition;
+                _instValues = _instControl.InstrumentValues;
+                _scans = _instControl.GetScans(false);
+                scanProcessor = new ScanProcessor(_scans, scan_processing_Method, scan_reporting_Method);
+
+                _instMSScanContainer = _instAccess.GetMsScanContainer(0);
+
+                //Trigger the acquisition to run a fnxn when these new events have occurred:
+                _instAcq.AcquisitionStreamOpening += _instAcq_AcquisitionStreamOpening;
+                _instAcq.AcquisitionStreamClosing += _instAcq_AcquisitionStreamClosing;
+                _instAcq.StateChanged += _instAcq_StateChanged;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                return false;
+            }
+        }
+    }
+}

--- a/examples/tribrid/scan-handler/InstrumentHandler_Outputs.cs
+++ b/examples/tribrid/scan-handler/InstrumentHandler_Outputs.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * 
+ * ScanHandler C# Implementation
+ * Author: Devin K Schweppe
+ * Copyright: 2022-2023 Schweppe Lab, University of Washington
+ * 
+ * Instrument handler extension for handling reports.
+ * 
+ */
+using ScanHandler.lib;
+using System;
+
+namespace ScanHandler
+{
+    public partial class InstrumentHandler
+    {
+        /// <summary>
+        /// Bind method to the report listener through an Action (e.g., button click)
+        /// </summary>
+        /// <param name="reportListener"></param>
+        /// <param name="bind"></param>
+        public void BindReportMethod(Action<object, ScanReportArgs> reportListener, bool bind = true)
+        {
+            if (scanProcessor == null)
+            {
+                return;
+            }
+            try
+            {
+                if (bind)
+                {
+                    scanProcessor.Report += new ScanReportHandler(reportListener);
+                }
+                else
+                {
+                    scanProcessor.Report -= new ScanReportHandler(reportListener);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+
+        /// <summary>
+        /// Example of how to make a report listener to send back processed data
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ReportListener(object sender, ScanReportArgs e)
+        {
+            DataReport report = e.Report;
+
+            try
+            {
+                // Do something cool
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+    }
+}

--- a/examples/tribrid/scan-handler/InstrumentHandler_Streams.cs
+++ b/examples/tribrid/scan-handler/InstrumentHandler_Streams.cs
@@ -1,0 +1,87 @@
+﻿/*
+ * 
+ * ScanHandler C# Implementation
+ * Author: Devin K Schweppe
+ * Copyright: 2022-2023 Schweppe Lab, University of Washington
+ * 
+ * For handling of instrument streams.
+ * 
+ */
+using System;
+using Thermo.Interfaces.InstrumentAccess_V1.Control.Acquisition;
+
+namespace ScanHandler
+{
+    public partial class InstrumentHandler
+    {
+        public bool ScanListenerBound { get; set; } = false;
+
+        /// <summary>
+        /// Bind the scan listener method for the MsScanArrived event
+        /// </summary>
+        /// <param name="bind"></param>
+        public void BindScanListenerToScanArrival(bool bind = true)
+        {
+            if (bind)
+            {
+                if (ScanListenerBound)
+                {
+                    return;
+                }
+                //Add filters here for if when to bind listener.
+                _instMSScanContainer.MsScanArrived += _instMSScanContainer_MsScanArrived;
+                ScanListenerBound = true;
+            }
+            else
+            {
+                if (!ScanListenerBound)
+                {
+                    return;
+                }
+                //Add filters here for if when to bind listener.
+                _instMSScanContainer.MsScanArrived -= _instMSScanContainer_MsScanArrived;
+                ScanListenerBound = false;
+            }
+        }
+
+        /// <summary>
+        /// Check when an acquisition ends, clear managed/unmanaged memory
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void _instAcq_AcquisitionStreamClosing(object sender, EventArgs e)
+        {
+            //if scan listeners running, stop them
+            BindScanListenerToScanArrival(false);
+            bool scansCanceled = false;
+            try
+            {
+                //stop extra custom scans after stop button
+                if (_scans != null)
+                {
+                    scansCanceled = _scans.CancelCustomScan();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("AcquisitionStreamClosing: could not cancel custom scans. \n" + ex.ToString());
+            }
+
+            Console.WriteLine("AcquisitionStreamClosing: starting new file. Scans Cancelled = " + scansCanceled.ToString());
+        }
+
+        /// <summary>
+        /// Check when a new acquisition begins and pull Starting Information from the AOEA
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void _instAcq_AcquisitionStreamOpening(object sender, AcquisitionOpeningEventArgs e)
+        {
+            //if event listener not running, start it
+            BindScanListenerToScanArrival(true);
+            scanProcessor.ResetCancellationTokenSource();
+            Console.WriteLine("AcquisitionStreamOpening");
+
+        } // acquisition listener
+    }
+}

--- a/examples/tribrid/scan-handler/LICENSE
+++ b/examples/tribrid/scan-handler/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Devin Schweppe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/tribrid/scan-handler/Properties/AssemblyInfo.cs
+++ b/examples/tribrid/scan-handler/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ScanHandler")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ScanHandler")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5630a2c3-46f1-412b-9c3d-63cdbebc60e3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/examples/tribrid/scan-handler/README.md
+++ b/examples/tribrid/scan-handler/README.md
@@ -1,0 +1,35 @@
+# ScanHandler
+
+ScanHandler is an intermediate between user-based code and instrument control software.
+
+The main goal of ScanHandler was to make it easier to begin developing applications in C# to control mass spectrometric instrument acquisition. ScanHandler provides two general means to interface with the instrument.
+
+When you use ScanHandler, the workflow will start by using the `Run` method within the `InstrumentHandler`. In general these methods will wait on the instrument to move to a `Running` state in order to move forward. This means that be default ScanHandler will not work (unbind listening) unless an instrument method is running.
+
+`InstrumentHandler` will begin by binding a scan listener method event listener to allow your program to listen for new scans coming from the instrument. Binding a method to the scan listener is simply allowing the `_instMSScanContainer_MsScanArrived` method to listen for new scans arriving.
+
+## Scan Processing using InstrumentHandler
+ScanHandler provides functionality to `process` scans coming from an instrument API scan stream. In this case, scans are harvested from the `IScans` interface using the `GetScans` method.
+
+Using the `IFusionMsScanContainer` interface, ScanHandler builds a `ScanProcesser` within the `InstrumentHandler` class. The `ScanProcesser` is bound to the arrival of new scans through the `MsScanArrived` event. Event arrival allows for calling of the `GetScan` method from the `MsScanEventArgs`.
+
+Instatiating `ScanProcessor` requires the definition of delegate functions for both a `Func<Scan, Dictionary<string, string>> Scan_Processing_Method` and a `Func<Scan, Dictionary<string, string>> Scan_Report_Method`. 
+
+The scan is converted from the native `IMsScan` interface to a ScanHandler `Scan` by consuming pertinent information for real-time processing (e.g., `Centroid` information).
+
+Importantly, scan processing is done within a threadpool to allow for multithreaded analysis, though this will depend in part on the application underdevelopment. Scans are processed using the `ProcessNewScan` method that spawns a worker thread to analyze an incoming scan.
+
+Processing of scans calls the user defined `Scan_Processing_Method` to run on the newly created `Scan`.
+
+## Reports
+After processing the scan data, you may want to have your program execute some function. In ScanHandler this is done through the `NewReport` method that invokes a `Report` event. The default `DataReport` returns a string, bool, and dictionary for reporting on information that may be useful. The primary function of these classes in the report is to determine if a subsequent API `CustomScan` should be triggered.
+
+## Sending down CustomScans
+One of the primary functions of API programs is to send down new CustomScans based on the user controlled scan processing. Using the `ThermoApi` class, your program can do this using the `oncurrentQueue<Dictionary<string, string>> ScanQueue`. New scans are enqueued using `AddtoScanQueue`. The `ThermoApi` class is instantiated within the `ScanProcessor` class to allow a user to send new scans using the same thread that was user for scan processing. Users can also move this functionality outside of the scan processing methods if desired.
+
+## Binding multiple processing and reporting methods
+It should be noted that while the `ScanProcessor` only takes in one method, that the user can wrap multiple methods from their own code base into a single point delegate method to be run within ScanHandler. This may be useful for more complex analyses or the use of multiple codebases in serial. For example, integrating [Monocle](https://github.com/gygilab/Monocle) into code ahead of the users desired processing for monoisotopic peak estimation.
+
+
+## Troubleshooting
+We are releasing ScanHandler to help others get started building new real-time instrument control methods. If you run into trouble, please post in the [Issues](../../issues) page. 

--- a/examples/tribrid/scan-handler/ScanHandler.csproj
+++ b/examples/tribrid/scan-handler/ScanHandler.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5630A2C3-46F1-412B-9C3D-63CDBEBC60E3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ScanHandler</RootNamespace>
+    <AssemblyName>ScanHandler</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="API-2.0">
+      <HintPath>..\iapi\lib\API-2.0.dll</HintPath>
+    </Reference>
+    <Reference Include="Fusion.API-1.0">
+      <HintPath>..\iapi\lib\tribrid\Fusion.API-1.0.dll</HintPath>
+    </Reference>
+    <Reference Include="Spectrum-1.0">
+      <HintPath>..\iapi\lib\Spectrum-1.0.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Thermo.TNG.Factory">
+      <HintPath>..\iapi\lib\tribrid\Thermo.TNG.Factory.dll</HintPath>
+    </Reference>
+    <Reference Include="VI-1.0">
+      <HintPath>..\iapi\lib\VI-1.0.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="InstrumentHandler.cs" />
+    <Compile Include="InstrumentHandler_Outputs.cs" />
+    <Compile Include="InstrumentHandler_Streams.cs" />
+    <Compile Include="lib\Centroid.cs" />
+    <Compile Include="lib\DataReport.cs" />
+    <Compile Include="lib\MsOrderType.cs" />
+    <Compile Include="lib\Scan.cs" />
+    <Compile Include="ScanProcessor.cs" />
+    <Compile Include="lib\ScanReport.cs" />
+    <Compile Include="lib\ThermoApi.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/examples/tribrid/scan-handler/ScanHandler.sln
+++ b/examples/tribrid/scan-handler/ScanHandler.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32811.315
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScanHandler", "ScanHandler.csproj", "{5630A2C3-46F1-412B-9C3D-63CDBEBC60E3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5630A2C3-46F1-412B-9C3D-63CDBEBC60E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5630A2C3-46F1-412B-9C3D-63CDBEBC60E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5630A2C3-46F1-412B-9C3D-63CDBEBC60E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5630A2C3-46F1-412B-9C3D-63CDBEBC60E3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FBE65B4B-2626-4D4A-802F-B8E4B1E9258C}
+	EndGlobalSection
+EndGlobal

--- a/examples/tribrid/scan-handler/ScanProcessor.cs
+++ b/examples/tribrid/scan-handler/ScanProcessor.cs
@@ -1,0 +1,172 @@
+﻿/*
+ * 
+ * ScanHandler C# Implementation
+ * Author: Devin K Schweppe
+ * Copyright: 2022-2023 Schweppe Lab, University of Washington
+ * 
+ * Parent classes to handle scans.
+ * 
+ */
+using ScanHandler.lib;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Thermo.Interfaces.InstrumentAccess_V1.Control.Scans;
+
+namespace ScanHandler
+{
+    /// <summary>
+    /// ScanProcessor is the focal point of data processing, all processing starts here from raw scans.
+    /// </summary>
+    /// <typeparam name="Scan"></typeparam>
+    public class ScanProcessor
+    {
+        public ThermoApi API { get; set; }
+
+        /// <summary>
+        /// Update the scan processor with a new set of methods to handle each incoming scan. This abstracts method calls outside of the InstrumentHandler and Scan Processor so that they will be defined in the users program.
+        /// </summary>
+        /// <param name="_scans">An instatntiation of the IScans interface.</param>
+        /// <param name="new_scan_function">A method that will process an incoming scan.</param>
+        /// <param name="new_report_function">A method that will report on the results of a processed scan.</param>
+        public ScanProcessor(IScans _scans, Func<Scan, Dictionary<string, string>> new_scan_function,
+            Func<Scan, Dictionary<string, string>> new_report_function)
+        {
+            API = new ThermoApi(_scans);
+            // Set maximum number of threads to stop OOM ex
+            ThreadPool.SetMaxThreads(100, 100);
+
+            Scan_Processing_Method = new_scan_function;
+            if (new_report_function != null)
+            {
+                Scan_Report_Method = new_report_function;
+            }
+        }
+
+        /// <summary>
+        /// Method that is run to process a scan or scans 
+        /// </summary>
+        Func<Scan, Dictionary<string, string>> Scan_Processing_Method { get; set; }
+
+        /// <summary>
+        /// Method run to report on that scan or send down new scans
+        /// </summary>
+        Func<Scan, Dictionary<string, string>> Scan_Report_Method { get; set; }
+
+        /// <summary>
+        /// Enable thread cancellation for methods that may run long or need to be cancelled during processing.
+        /// </summary>
+        public CancellationTokenSource CancellationSource { get; set; } = new CancellationTokenSource();
+
+        public void ResetCancellationTokenSource()
+        {
+            CancellationSource = new CancellationTokenSource();
+        }
+
+        /// <summary>
+        /// Cancel analysis if there is currently a locked or long running analysis
+        /// </summary>
+        /// <param name="state"></param>
+        public void StartProcessingTimeOut(object state)
+        {
+            AutoResetEvent processingTimeOutEvent = (AutoResetEvent)state;
+            Thread.Sleep(25);
+            processingTimeOutEvent.Set();
+        }
+
+        private static WaitHandle[] WaitHandles = new WaitHandle[]
+        {
+            new AutoResetEvent(false),
+            new AutoResetEvent(false)
+        };
+
+        /// <summary>
+        /// Process the current scan using thread pool
+        /// </summary>
+        /// <param name="newScan"></param>
+        public virtual void ProcessNewScan(Scan newScan)
+        {
+            try
+            {
+                int waitIndex = -1;
+                ThreadPool.QueueUserWorkItem(StartProcessingTimeOut, WaitHandles[0]);
+                ThreadPool.QueueUserWorkItem(RunProcessingThread, new object[] { newScan, WaitHandles[1] });
+                waitIndex = WaitHandle.WaitAny(WaitHandles);
+                if (waitIndex < 1)
+                {
+                   // Console.WriteLine("Cancelling scan processing for scan: " + newScan.ScanNumber);
+                    //
+                    // Cancel processing here if added.
+                    //
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+
+        /// <summary>
+        /// Method to run on a thread within the threadpool to process a given scan in a user defined way.
+        /// </summary>
+        /// <param name="state"></param>
+        public void RunProcessingThread(object state)
+        {
+            if (state == null)
+            {
+                Console.WriteLine("Scan state was null!");
+                return;
+            }
+
+            object[] stateArray = state as object[];
+            AutoResetEvent processingFinishEvent = (AutoResetEvent)stateArray[1];
+
+            Scan newScan = (Scan)stateArray[0];
+
+            if (newScan != null) /* is the new scan is interesting? */
+            {
+                DataReport report = new DataReport();
+                report.ReportDataDictionary = Scan_Processing_Method(newScan);
+                NewReport(report);
+            }
+            processingFinishEvent.Set();
+        }
+
+        /// <summary>
+        /// Event handlers for reporting scan and analysis data
+        /// </summary>
+        public event ScanReportHandler Report;
+
+        /// <summary>
+        /// Invoke listener for when a new report needs to be processed
+        /// </summary>
+        protected virtual void NewReport(DataReport report)
+        {
+            if (report == null)
+            {
+                Console.WriteLine("NewReport Failed, report was null.");
+            }
+
+            Report?.Invoke(this, new ScanReportArgs(report));
+        }
+        public void ResetProcessing(bool startNew)
+        {
+            try
+            {
+                if (CancellationSource != null && !CancellationSource.IsCancellationRequested)
+                {
+                    CancellationSource.Cancel();
+                    Thread.Sleep(500);
+                    CancellationSource.Dispose();
+                    ResetCancellationTokenSource();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Excpetion thrown when resetting processing: \n" + ex.ToString());
+            }
+
+        }
+
+    }
+}

--- a/examples/tribrid/scan-handler/lib/Centroid.cs
+++ b/examples/tribrid/scan-handler/lib/Centroid.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * 
+ * ScanHandler C# Implementation
+ * Author: Devin K Schweppe
+ * Copyright: 2022-2023 Schweppe Lab, University of Washington
+ * 
+ * Centroid clas for spectral information.
+ * 
+ */
+using System;
+using System.Linq;
+
+namespace ScanHandler.lib
+{
+    /// <summary>
+    /// for pulling spectral information from API scans
+    /// </summary>
+    public class Centroid : IComparable
+    {
+        public double Mz { get; set; } = 500;
+        public double Precursor { get; set; } = 500;
+        public double Intensity { get; set; } = 0;
+        public double Noise { get; set; } = 0;
+        public int? Resolution { get; set; } = null;
+
+        public bool? IsMonoisotopic { get; set; } = false;
+
+        public bool? IsClusterTop { get; set; } = false;
+
+        public int? Charge { get; set; } = null;
+
+        public int CompareTo(object obj)
+        {
+            if (obj == null) return 1;
+
+            if (obj is Centroid otherCentroid)
+            {
+                return Intensity.CompareTo(otherCentroid.Intensity);
+            }
+            else
+            {
+                throw new ArgumentException("Object is not a Centroid");
+            }
+        }
+    }
+}

--- a/examples/tribrid/scan-handler/lib/DataReport.cs
+++ b/examples/tribrid/scan-handler/lib/DataReport.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * 
+ * ScanHandler C# Implementation
+ * Author: Devin K Schweppe
+ * Copyright: 2022-2023 Schweppe Lab, University of Washington
+ *  
+ * Data report class for ScanHandler.
+ * 
+ */
+using System.Collections.Generic;
+
+namespace ScanHandler.lib
+{
+    /// <summary>
+    /// Empty class for desginating relevant information from your processed data as a report for display or export.
+    /// </summary>
+    public class DataReport
+    {
+        public string data { get; set; }
+
+        public bool sendNewScan { get; set; } = true;
+
+        public Dictionary<string, string> ReportDataDictionary { get; set; }
+    }
+}

--- a/examples/tribrid/scan-handler/lib/MsOrderType.cs
+++ b/examples/tribrid/scan-handler/lib/MsOrderType.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * 
+ * ScanHandler C# Implementation
+ * Author: Devin K Schweppe
+ * Copyright: 2022-2023 Schweppe Lab, University of Washington
+ * 
+ * MS Order type up to MS5
+ * 
+ */
+namespace ScanHandler.lib
+{
+    //
+    // Specify scan order.
+    public enum MSOrderType
+    {
+        Any = 0,
+        //Precursor MS1
+        Ms = 1,
+        // MS^2 (MS/MS)
+        Ms2 = 2,
+        Ms3 = 3,
+        Ms4 = 4,
+        Ms5 = 5
+    }
+}

--- a/examples/tribrid/scan-handler/lib/Scan.cs
+++ b/examples/tribrid/scan-handler/lib/Scan.cs
@@ -1,0 +1,101 @@
+﻿/*
+ * 
+ * ScanHandler C# Implementation
+ * Author: Devin K Schweppe
+ * Copyright: 2022-2023 Schweppe Lab, University of Washington
+ * 
+ * Scan class.
+ * 
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Thermo.Interfaces.SpectrumFormat_V1;
+
+namespace ScanHandler.lib
+{
+    /// <summary>
+    /// Class to harvest IMsScan information without holding memory consuming IMsScan class.
+    /// </summary>
+    public class Scan : IDisposable
+    {
+        public int ScanNumber { get; set; }
+        public int ParentScanNumber { get; set; }
+        public int MsOrder { get; set; }
+        public double PrecursorMz { get; set; }
+        public double PrecursorMz2 { get; set; }
+        public string ScanDescription { get; set; }
+        public double CollisionEnergy { get; set; }
+        public double MonoisotopicMz { get; set; }
+        public int PrecursorCharge { get; set; }
+        public int CentroidCount { get; private set; }
+        public string FAIMS_Voltages { get; set; } = "On";
+        public string FAIMS_CV { get; set; } = "0";
+        public Centroid[] Centroids { get; private set; }
+        public int NoiseCount { get; set; }
+        public IEnumerable<INoiseNode> NoiseBand { get; set; }
+
+        /// <summary>
+        /// Convert the API scan class to the ScanHandler scan class
+        /// </summary>
+        /// <param name="InterfaceCentroids"></param>
+        public void ConvertIMsScan(IEnumerable<ICentroid> InterfaceCentroids)
+        {
+            int centroidIndex = 0;
+            CentroidCount = InterfaceCentroids.Count();
+            Centroids = new Centroid[CentroidCount];
+            //Console.WriteLine("Converter: " + ScanNumber.ToString());
+
+            foreach (ICentroid centroid in InterfaceCentroids)
+            {
+                try
+                {
+                    Centroids[centroidIndex] = new Centroid();
+                    Centroids[centroidIndex].Mz = centroid.Mz;
+                    Centroids[centroidIndex].Intensity = centroid.Intensity;
+                    Centroids[centroidIndex].Resolution = (int?)centroid.Resolution;
+                    Centroids[centroidIndex].IsMonoisotopic = centroid.IsMonoisotopic;
+                    Centroids[centroidIndex].IsClusterTop = centroid.IsClusterTop;
+                    Centroids[centroidIndex].Charge = centroid.Charge;
+                    centroidIndex++;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex);
+                }
+
+            }
+            InterfaceCentroids = null;
+        }
+
+        // Flag: Has Dispose already been called?
+        bool disposed = false;
+
+        ~Scan()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            // Dispose of unmanaged resources.
+            Dispose(true);
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
+        }
+
+        // Protected implementation of Dispose pattern.
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+                return;
+
+            if (disposing)
+            {
+                Centroids = null;
+            }
+
+            disposed = true;
+        }
+    }
+}

--- a/examples/tribrid/scan-handler/lib/ScanReport.cs
+++ b/examples/tribrid/scan-handler/lib/ScanReport.cs
@@ -1,0 +1,22 @@
+﻿/*
+ * 
+ * ScanHandler C# Implementation
+ * Author: Devin K Schweppe
+ * Copyright: 2022-2023 Schweppe Lab, University of Washington
+ * 
+ * Scan report to return for ongoing usage.
+ * 
+ */
+using System;
+
+namespace ScanHandler.lib
+{
+
+    public delegate void ScanReportHandler(Object sender, ScanReportArgs e);
+
+    public class ScanReportArgs : EventArgs
+    {
+        public DataReport Report;
+        public ScanReportArgs(DataReport report) { Report = report; }
+    }
+}

--- a/examples/tribrid/scan-handler/lib/ThermoApi.cs
+++ b/examples/tribrid/scan-handler/lib/ThermoApi.cs
@@ -1,0 +1,92 @@
+﻿/*
+ * 
+ * ScanHandler C# Implementation
+ * Author: Devin K Schweppe
+ * Copyright: 2022-2023 Schweppe Lab, University of Washington
+ * 
+ * Interfacing class for the Thermo API
+ * 
+ */
+using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using Thermo.Interfaces.InstrumentAccess_V1.Control.Scans;
+
+namespace ScanHandler.lib
+{
+    /// <summary>
+    /// Interface for the Thermo API to send scans to the instrument
+    /// </summary>
+    public class ThermoApi
+    {
+        private IScans _scans { get; set; }
+       public ConcurrentQueue<Dictionary<string, string>> ScanQueue { get; set; }
+
+        public void AddtoScanQueue(Dictionary<string, string> newScan)
+        {
+            ScanQueue.Enqueue(newScan);
+        }
+        public ThermoApi(IScans scans)
+        {
+            _scans = scans;
+
+        }
+
+        /// <summary>
+        /// Update custom scan params and submit custom scan
+        /// </summary>
+        /// <param name="newValuesDict"></param>
+        /// <param name="parentScanNumber"></param>
+        public void Submit_New_Scan(Dictionary<string, string> newValuesDict, long parentScanNumber)
+        {
+            try
+            {
+                ICustomScan cs = _scans.CreateCustomScan();
+                _scans.CancelCustomScan();
+                cs.RunningNumber = parentScanNumber;
+                string logMessage = $"Submitting new scan with ParentScanNumber: {parentScanNumber}\n";
+                if (newValuesDict.Count > 0)
+                {
+                    foreach (KeyValuePair<string, string> kvpParam in newValuesDict)
+                    {
+                        cs.Values[kvpParam.Key] = kvpParam.Value;
+                    }
+                    // Force processing delay to ensure scans do not clash
+                    cs.SingleProcessingDelay = 0.005;
+                    bool? testCSsent = _scans.SetCustomScan(cs);
+                    cs = null;
+                }
+            }
+            catch (Exception ScanException)
+            {
+                Console.WriteLine("Scan Inject Error: " + ScanException);
+            }
+
+        }
+        /// <summary>
+        /// A collection of some of the basic and useful scan parameters that can be included when building a new custom scan.
+        /// </summary>
+        private class ScanParameters
+        {
+            public string Analyzer { get; set; } = "Ion Trap";
+            public string OrbitrapResolution { get; set; } = "50000";
+            public string ScanType { get; set; } = "MSn";
+            public string AGCTarget { get; set; } = "100000";
+            public string MaxIT { get; set; } = "250";
+            public string Dependent { get; set; } = "True";
+            public string ActivationType { get; set; } = "CID;HCD";
+            public string CollisionEnergy { get; set; } = "35;45";
+            public string SrcRFLens { get; set; } = "30";
+            public string FirstMass { get; set; } = "120";
+            public string LastMass { get; set; } = "1500";
+            public string IsolationWidth { get; set; } = "1.2;2.0";
+            public string ActivationQ { get; set; } = "0.25;0.25";
+            public string DataType { get; set; } = "Centroid";
+            public string Polarity { get; set; } = "Positive";
+            public string Microscans { get; set; } = "1";
+            public string SourceCIDEnergy { get; set; } = "0";
+            public string IsolationMode { get; set; } = "Quadrupole";
+        }
+
+    }
+}


### PR DESCRIPTION
# ScanHandler

ScanHandler is an intermediate between user-based code and instrument control software.

The main goal of ScanHandler was to make it easier to begin developing applications in C# to control mass spectrometric instrument acquisition. ScanHandler provides two general means to interface with the instrument.
