### PR TITLE
Fixing bug with old syringe pump model F100T2

### DIFF
--- a/examples/tribrid/FusionExampleClient2pt0/Form1.cs
+++ b/examples/tribrid/FusionExampleClient2pt0/Form1.cs
@@ -887,9 +887,9 @@ namespace FusionExampleClient
 
                  if (setControls)
                  {
-                     numericUpDown1.Value = decimal.Parse(diamterRB.Text);
-                     numericUpDown2.Value = decimal.Parse(volumeRB.Text);
-                     numericUpDown3.Value = decimal.Parse(flowrateRB.Text);
+                     numericUpDown1.Value = (decimal)_syringe.Diameter;
+                     numericUpDown2.Value = (decimal)_syringe.Volume;
+                     numericUpDown3.Value = (decimal)_syringe.FlowRate; // was decimal.Parse(), conflicts with F100T2 syringe pump here; F100T2 is no longer supported
                  }
 
              }));


### PR DESCRIPTION
For FusionExample2tp0, GetInstrumentAccess initialized syringe controls by parsing display strings formatted with `ToString("g3")`. Small values could be rendered in scientific notation and throw `FormatException`. Fix by assigning the numeric-up-down values directly from the syringe numeric properties instead of parsing the formatted text. The original bug was caused by outdated F100T2 syringe pump. 